### PR TITLE
With bias T and TCXO correction

### DIFF
--- a/SoapyFCDPP/SoapyFCDPP.cpp
+++ b/SoapyFCDPP/SoapyFCDPP.cpp
@@ -425,11 +425,13 @@ void SoapyFCDPP::setFrequencyCorrection(const int direction, const size_t channe
   SoapySDR_logf(SOAPY_SDR_DEBUG, "setFreqCorrection %f", value);
   d_trim_ppm = value;
 
-  int err = fcdpp_set_freq_hz(d_handle, uint32_t(d_frequency), d_trim_ppm);
-  if (err <= 0) {
-    SoapySDR_log(SOAPY_SDR_ERROR, "setFrequencyCorrection failed to set device frequency");
-  }
-
+  if (d_frequency != 0.0)	// don't set correction until tuned initially
+    {
+      int err = fcdpp_set_freq_hz(d_handle, uint32_t(d_frequency), d_trim_ppm);
+      if (err <= 0) {
+	SoapySDR_log(SOAPY_SDR_ERROR, "setFrequencyCorrection failed to set device frequency");
+      }
+    }
 }
 
 double SoapyFCDPP::getFrequencyCorrection(const int direction, const size_t channel) const

--- a/SoapyFCDPP/SoapyFCDPP.hpp
+++ b/SoapyFCDPP/SoapyFCDPP.hpp
@@ -33,8 +33,10 @@ private:
     const double d_sample_rate;
     double d_frequency;
     double d_lna_gain;
+    double d_bias_tee;
     double d_mixer_gain;
     double d_if_gain;
+    double d_trim_ppm;
     const std::string d_hid_path;
     const std::string d_alsa_device;
     
@@ -105,8 +107,16 @@ public:
     std::vector<std::string> listFrequencies(const int direction, const size_t channel) const;
     SoapySDR::RangeList getFrequencyRange(const int direction, const size_t channel, const std::string &name) const;
     SoapySDR::ArgInfoList getFrequencyArgsInfo(const int direction, const size_t channel) const;
-    
-    // Sample Rate API
+
+  // Correction
+
+    bool hasFrequencyCorrection(const int direction, const size_t channel) const;
+
+    void setFrequencyCorrection(const int direction, const size_t channel, const double value);
+
+    double getFrequencyCorrection(const int direction, const size_t channel) const;
+
+  // Sample Rate API
     void setSampleRate(const int direction, const size_t channel, const double rate);
     double getSampleRate(const int direction, const size_t channel) const;
     std::vector<double> listSampleRates(const int direction, const size_t channel) const;

--- a/SoapyFCDPP/fcd.c
+++ b/SoapyFCDPP/fcd.c
@@ -76,6 +76,28 @@ int fcdpp_set_lna_gain(hid_device *device, uint8_t gain)
     return err;
 }
 
+// Get BIAST gain on/off
+int fcdpp_get_bias_tee(hid_device *device)
+{
+    int err;
+    uint8_t buf[BUF_LEN] = { 0x00 };
+    buf[1] = FCD_HID_CMD_GET_BIAS_TEE;
+    err = hid_wr_timeout(device, buf, BUF_LEN);
+    if (err < 0) return err;
+    return buf[2];
+}
+
+// Set BIAST gain on/off
+int fcdpp_set_bias_tee(hid_device *device, uint8_t gain)
+{
+    int err = 0;
+    uint8_t buf[BUF_LEN] = { 0x00 };
+    buf[1] = FCD_HID_CMD_SET_BIAS_TEE;
+    buf[2] = gain;
+    err = hid_write(device, buf, BUF_LEN);
+    return err;
+}
+
 tuner_rf_filter_t fcdpp_get_rf_filter(hid_device *device)
 {
     int err = 0;
@@ -157,6 +179,7 @@ int fcdpp_set_mixer_gain(hid_device *device, uint8_t gain)
     return err;
 }
 
+#if 0
 int fcdpp_get_bias_tee(hid_device *device)
 {
     // TODO
@@ -168,10 +191,11 @@ int fcdpp_set_bias_tee(hid_device *device, uint8_t tee)
     // TODO
     return -1;
 }
-
-int fcdpp_set_freq_hz(hid_device *device, uint32_t freq) {
+#endif
+int fcdpp_set_freq_hz(hid_device *device, uint32_t freq, double trim) {
     int err;
     uint8_t buf[BUF_LEN] = { 0x00 };
+    freq = (uint32_t)((double) freq * (1+(1e-6*trim)));
     // buf[0] is ignored by the FCDP+
     buf[1] = FCD_HID_CMD_SET_FREQUENCY_HZ;
     buf[2] = (uint8_t) (freq);

--- a/SoapyFCDPP/fcd.h
+++ b/SoapyFCDPP/fcd.h
@@ -31,7 +31,7 @@ extern "C"
     int fcdpp_set_bias_tee(hid_device *device, uint8_t tee);
     int fcdpp_get_mixer_gain(hid_device *device);
     int fcdpp_set_mixer_gain(hid_device *device, uint8_t gain);
-    int fcdpp_set_freq_hz(hid_device *device, uint32_t freq);
+    int fcdpp_set_freq_hz(hid_device *device, uint32_t freq, double ppm);
     int fcdpp_set_freq_khz(hid_device *device, uint32_t freq);
     int fcdpp_get_freq_hz(hid_device *device);
     //void log_status(hid_device *device);


### PR DESCRIPTION
I am using an FCDPP for meteor scatter off the GRAVES radar, so I needed bias tee for the pre-amp.
My FCDPP is well off frequency (8.4ppm) , so I also added frequency correction. (Since there's none in the hardware, I apply the correction as the FCDPP is being loaded)

If these patches are useful, please have them