### PR TITLE
FCD Pro (V1.x) and Debian buster (stable) supported

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@
 cmake_minimum_required(VERSION 2.8.7)
 project(SoapyFCDPP CXX C)
 
-find_package(SoapySDR "0.6.0...0.7.0" NO_MODULE)
+find_package(SoapySDR "0.6.0" NO_MODULE)
 if (NOT SoapySDR_FOUND)
     message(FATAL_ERROR "Soapy SDR development files not found...") 
 endif ()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@
 cmake_minimum_required(VERSION 2.8.7)
 project(SoapyFCDPP CXX C)
 
-find_package(SoapySDR "0.7.0" NO_MODULE)
+find_package(SoapySDR "0.6.0" NO_MODULE)
 if (NOT SoapySDR_FOUND)
     message(FATAL_ERROR "Soapy SDR development files not found...") 
 endif ()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@
 cmake_minimum_required(VERSION 2.8.7)
 project(SoapyFCDPP CXX C)
 
-find_package(SoapySDR "0.6.0" NO_MODULE)
+find_package(SoapySDR "0.6.0...0.7.0" NO_MODULE)
 if (NOT SoapySDR_FOUND)
     message(FATAL_ERROR "Soapy SDR development files not found...") 
 endif ()

--- a/SoapyFCDPP/SoapyFCDPP.cpp
+++ b/SoapyFCDPP/SoapyFCDPP.cpp
@@ -231,7 +231,7 @@ int SoapyFCDPP::readStream(SoapySDR::Stream *stream,
             if(snd_pcm_recover(d_pcm_handle, err, 0) == 0) {
                 // Recover ok
                 SoapySDR_logf(SOAPY_SDR_ERROR,
-                              "readStream recoverd from %s",
+                              "readStream recovered from %s",
                               snd_strerror(err));
                 return SOAPY_SDR_OVERFLOW;
             } else {
@@ -438,7 +438,7 @@ void SoapyFCDPP::setFrequency(const int direction,
                               const double frequency,
                               const SoapySDR::Kwargs &args)
 {
-    SoapySDR_log(SOAPY_SDR_DEBUG, "setFrequency");
+    SoapySDR_logf(SOAPY_SDR_DEBUG, "setFrequency: %f", frequency);
     
     int err = 1;
     
@@ -600,7 +600,7 @@ std::string findAlsaDevice(const char *hidpath)
 
 SoapySDR::KwargsList findFCDPP(const SoapySDR::Kwargs &args)
 {
-    SoapySDR_log(SOAPY_SDR_INFO, "findFCDPP");
+    SoapySDR_log(SOAPY_SDR_TRACE, "findFCDPP");
     
     SoapySDR::KwargsList results;
     
@@ -637,7 +637,7 @@ SoapySDR::KwargsList findFCDPP(const SoapySDR::Kwargs &args)
     }
     hid_free_enumeration(devs);
     
-    SoapySDR_logf(SOAPY_SDR_INFO, "findFCDPP=%d devices", results.size());
+    SoapySDR_logf(SOAPY_SDR_TRACE, "findFCDPP=%d devices", results.size());
     return results;
 }
 

--- a/SoapyFCDPP/SoapyFCDPP.cpp
+++ b/SoapyFCDPP/SoapyFCDPP.cpp
@@ -369,12 +369,17 @@ SoapySDR::Range SoapyFCDPP::getGainRange(const int direction, const size_t chann
 {
     SoapySDR_log(SOAPY_SDR_DEBUG, "getGainRange");
     
+    // Pro+ gains taken from the comments here: http://www.funcubedongle.com/?page_id=1225
+    // Pro gains from datasheet of E4000
     if (name == "LNA") {
-        return is_pro_plus ? SoapySDR::Range(0,1,1) : SoapySDR::Range(-5.0,30,2.5);
+        // Pro+ LNA is 0/+10dB switchable
+        return is_pro_plus ? SoapySDR::Range(0,10,10) : SoapySDR::Range(-5.0,30,2.5);
     } else if (name == "Mixer") {
-        return SoapySDR::Range(4,12,8);
+        // Pro+ Mixer is 0/+20dB switchable
+        return is_pro_plus ? SoapySDR::Range(0,20,20) : SoapySDR::Range(4,12,8);
     } else if (name == "IF"){
-        return SoapySDR::Range(3,57,1);
+        // Pro+ IF is 0-59dB in 1dB steps
+        return is_pro_plus ? SoapySDR::Range(0,59,1) : SoapySDR::Range(3,57,1);
     } else {
         throw std::runtime_error("getGainRange: unknown gain element");
     }

--- a/SoapyFCDPP/SoapyFCDPP.hpp
+++ b/SoapyFCDPP/SoapyFCDPP.hpp
@@ -7,7 +7,7 @@
 
 #include <SoapySDR/Device.hpp>
 #include <SoapySDR/Registry.hpp>
-#include <SoapySDR/ConverterRegistry.hpp>
+//#include <SoapySDR/ConverterRegistry.hpp>
 
 #include <cstdint>
 #include <iostream>
@@ -40,7 +40,7 @@ private:
     const std::string d_hid_path;
     const std::string d_alsa_device;
     
-    SoapySDR::ConverterRegistry::ConverterFunction d_converter_func;
+//    SoapySDR::ConverterRegistry::ConverterFunction d_converter_func;
 
     // hid
     hid_device *d_handle;

--- a/SoapyFCDPP/SoapyFCDPP.hpp
+++ b/SoapyFCDPP/SoapyFCDPP.hpp
@@ -20,17 +20,20 @@
 // This is for the funcube dongle pro+
 #define FCDPP_VENDOR_ID     0x04d8
 #define FCDPP_PRODUCT_ID    0xfb31
+// This is the older funcube dongle pro
+#define FCDP_PRODUCT_ID     0xfb56
 
 class SoapyFCDPP : public SoapySDR::Device
 {
     
 private:
+    const bool is_pro_plus;
     snd_pcm_t* d_pcm_handle;
     uint32_t d_period_size;
     std::vector<int32_t> d_buff;
 
     // Device properties
-    const double d_sample_rate;
+    double d_sample_rate;
     double d_frequency;
     double d_lna_gain;
     double d_bias_tee;
@@ -42,11 +45,14 @@ private:
     
 //    SoapySDR::ConverterRegistry::ConverterFunction d_converter_func;
 
+    // FCD V1 gain mapper
+    uint8_t mapLNAGain(double db);
+
     // hid
     hid_device *d_handle;
     
 public:
-    SoapyFCDPP(const std::string &hid_path, const std::string &alsa_device);
+    SoapyFCDPP(const std::string &hid_path, const std::string &alsa_device, const bool is_plus);
     ~SoapyFCDPP();
     
     // Identification API

--- a/SoapyFCDPP/SoapyFCDPP.hpp
+++ b/SoapyFCDPP/SoapyFCDPP.hpp
@@ -54,7 +54,7 @@ private:
 #endif
 
     // FCD V1 gain mapper
-    uint8_t mapLNAGain(double db);
+    uint8_t mapLNAGain(double db, double *actual);
 
     // hid
     hid_device *d_handle;

--- a/SoapyFCDPP/SoapyFCDPP.hpp
+++ b/SoapyFCDPP/SoapyFCDPP.hpp
@@ -7,7 +7,10 @@
 
 #include <SoapySDR/Device.hpp>
 #include <SoapySDR/Registry.hpp>
-//#include <SoapySDR/ConverterRegistry.hpp>
+#include <SoapySDR/Version.hpp>
+#if SOAPY_SDR_API_VERSION >= 0x00070000
+#include <SoapySDR/ConverterRegistry.hpp>
+#endif
 
 #include <cstdint>
 #include <iostream>
@@ -21,7 +24,7 @@
 #define FCDPP_VENDOR_ID     0x04d8
 #define FCDPP_PRODUCT_ID    0xfb31
 // This is the older funcube dongle pro
-#define FCDP_PRODUCT_ID     0xfb56
+#define FCD_PRODUCT_ID      0xfb56
 
 class SoapyFCDPP : public SoapySDR::Device
 {
@@ -43,7 +46,12 @@ private:
     const std::string d_hid_path;
     const std::string d_alsa_device;
     
-//    SoapySDR::ConverterRegistry::ConverterFunction d_converter_func;
+#if SOAPY_SDR_API_VERSION >= 0x00070000
+    SoapySDR::ConverterRegistry::ConverterFunction d_converter_func;
+#else
+    bool is_cf32;
+    void convertCS16toCF32(void *dst, void *src, size_t samples);
+#endif
 
     // FCD V1 gain mapper
     uint8_t mapLNAGain(double db);

--- a/SoapyFCDPP/alsa.c
+++ b/SoapyFCDPP/alsa.c
@@ -6,6 +6,7 @@
 
 /* Try to get an ALSA capture handle */
 snd_pcm_t* alsa_pcm_handle(const char* pcm_name,
+                           const unsigned int rate,
                            snd_pcm_uframes_t frames_per_period,
                            snd_pcm_stream_t stream) {
     snd_pcm_t *pcm_handle = NULL;
@@ -13,9 +14,8 @@ snd_pcm_t* alsa_pcm_handle(const char* pcm_name,
     snd_pcm_hw_params_t *hwparams;
     //snd_pcm_sw_params_t *swparams;
     
-    const unsigned int rate = 192000;      // Fixed sample rate of VFZSDR.
     const unsigned int periods = 4;       // Number of periods in ALSA ringbuffer.
-    const unsigned int channels = 2;
+    const unsigned int channels = 2;      // Always 2 channel IQ samples
     
     snd_pcm_hw_params_alloca(&hwparams);
     // snd_pcm_sw_params_alloca(&swparams);

--- a/SoapyFCDPP/alsa.h
+++ b/SoapyFCDPP/alsa.h
@@ -14,6 +14,7 @@ extern "C"
 #include <alsa/asoundlib.h>
     
     snd_pcm_t* alsa_pcm_handle(const char* pcm_name,
+                               const unsigned int rate,
                                snd_pcm_uframes_t frames_per_period,
                                snd_pcm_stream_t stream);
     

--- a/SoapyFCDPP/fcd.c
+++ b/SoapyFCDPP/fcd.c
@@ -30,6 +30,24 @@
  }
  */
 
+// gain ranges for each stage in FCD Pro (V1.x)
+static int8_t gains1[]={-3,6};
+static int8_t gains2[]={0,3,6,9};
+static int8_t gains3[]={0,3,6,9};
+static int8_t gains4[]={0,1,2,3};
+static int8_t gains5[]={3,6,9,12,15};
+static int8_t gains6[]={3,6,9,12,15};
+static int8_t *if_gains[]={gains1, gains2, gains3, gains4, gains5, gains6};
+
+// gain distribution cutoff points (see below for usage)
+static int8_t cutoff1[]={1,45};
+static int8_t cutoff2[]={6,39,42,45,48,51,54};
+static int8_t cutoff3[]={3,30,33,36};
+static int8_t cutoff4[]={0};
+static int8_t cutoff5[]={4,18,21,24,27};
+static int8_t cutoff6[]={4,6,9,12,15};
+static int8_t *cutoffs[]={cutoff1,cutoff2,cutoff3,cutoff4,cutoff5,cutoff6};
+
 // Helper function.
 // Write content of buffer, then read reply into the same buffer.
 int hid_wr_timeout(hid_device *device, uint8_t* buf, uint8_t len)
@@ -139,24 +157,83 @@ int fcdpp_set_if_filter(hid_device *device)
     return err;
 }
 
-int fcdpp_get_if_gain(hid_device *device)
+int fcdpp_get_if_gain(hid_device *device, uint8_t is_plus)
 {
-    int err = 0;
-    uint8_t buf[BUF_LEN] = { 0x00 };
-    buf[1] = FCD_HID_CMD_GET_IF_GAIN;
-    err = hid_wr_timeout(device, buf, BUF_LEN);
-    if (err < 0) return err;
-    return buf[2];
+    if (is_plus) {
+	    int err = 0;
+	    uint8_t buf[BUF_LEN] = { 0x00 };
+	    buf[1] = FCD_HID_CMD_GET_IF_GAIN;
+	    err = hid_wr_timeout(device, buf, BUF_LEN);
+	    if (err < 0) return err;
+	    return buf[2];
+    } else {
+        // Read all gain registers, map and add together..
+        uint8_t regs[] = {
+            FCD_HID_CMD_GET_IF_GAIN1,
+            FCD_HID_CMD_GET_IF_GAIN2,
+            FCD_HID_CMD_GET_IF_GAIN3,
+            FCD_HID_CMD_GET_IF_GAIN4,
+            FCD_HID_CMD_GET_IF_GAIN5,
+            FCD_HID_CMD_GET_IF_GAIN6
+        };
+        int8_t sum = 0;
+        for (int i=0; i<6; i++) {
+            int err = 0;
+            uint8_t buf[BUF_LEN] = { 0x00 };
+            buf[1] = regs[i];
+            err = hid_wr_timeout(device, buf, BUF_LEN);
+            if (err < 0) return err;
+            sum += if_gains[i][buf[2]];
+        }
+        return sum;
+    }
 }
 
-int fcdpp_set_if_gain(hid_device *device, uint8_t gain)
+int fcdpp_set_if_gain(hid_device *device, uint8_t is_plus, uint8_t gain)
 {
-    int err = 0;
-    uint8_t buf[BUF_LEN] = { 0x00 };
-    buf[1] = FCD_HID_CMD_SET_IF_GAIN;
-    buf[2] = gain;
-    err = hid_write(device, buf, BUF_LEN);
-    return err;
+    if (is_plus) {
+	    int err = 0;
+	    uint8_t buf[BUF_LEN] = { 0x00 };
+	    buf[1] = FCD_HID_CMD_SET_IF_GAIN;
+	    buf[2] = gain;
+	    err = hid_write(device, buf, BUF_LEN);
+	    return err;
+    } else {
+        // distribute requested gain according to the table on pages 38-9
+        // of the datasheet: https://www.nooelec.com/files/e4000datasheet.pdf
+        // in 'linearity mode'. We use cutoff values derived from the table
+        // for most gains, apart from gain4 which is (gain mod 3)..and gain2
+        // which gets reduced by 3 if gain1 is set - neat =)
+        int err = 0;
+        uint8_t regs[]={
+            FCD_HID_CMD_SET_IF_GAIN1,
+            FCD_HID_CMD_SET_IF_GAIN2,
+            FCD_HID_CMD_SET_IF_GAIN3,
+            FCD_HID_CMD_SET_IF_GAIN4,
+            FCD_HID_CMD_SET_IF_GAIN5,
+            FCD_HID_CMD_SET_IF_GAIN6
+        };
+        uint8_t pv=0;
+        for (int i=0; i<6; i++) {
+            int8_t *cutoff=cutoffs[i];
+            uint8_t val=0;
+            for (uint8_t j=1; j<=cutoff[0]; j++) {
+                if (gain>=cutoff[j])
+                    val = j;
+            }
+            // special cases
+            if (1==i && pv) val-=3;
+            if (3==i) val=gain%3;
+            pv = val;
+            // write to FCD
+            uint8_t buf[BUF_LEN] = { 0x00 };
+            buf[1] = regs[i];
+            buf[2] = val;
+            err = hid_write(device, buf, BUF_LEN);
+            if (err<0) break;
+        }
+        return err;
+    }
 }
 
 int fcdpp_get_mixer_gain(hid_device *device) {

--- a/SoapyFCDPP/fcd.h
+++ b/SoapyFCDPP/fcd.h
@@ -25,8 +25,8 @@ extern "C"
     int fcdpp_set_rf_filter(hid_device *device, tuner_rf_filter_t filter);
     tuner_if_filter_t fcdpp_get_if_filter(hid_device *device);
     int fcdpp_set_if_filter(hid_device *device);
-    int fcdpp_get_if_gain(hid_device *device);
-    int fcdpp_set_if_gain(hid_device *device, uint8_t gain);
+    int fcdpp_get_if_gain(hid_device *device, uint8_t is_plus);
+    int fcdpp_set_if_gain(hid_device *device, uint8_t is_plus, uint8_t gain);
     int fcdpp_get_bias_tee(hid_device *device);
     int fcdpp_set_bias_tee(hid_device *device, uint8_t tee);
     int fcdpp_get_mixer_gain(hid_device *device);

--- a/SoapyFCDPP/fcdcmd.h
+++ b/SoapyFCDPP/fcdcmd.h
@@ -29,6 +29,21 @@ extern "C"
 
 #define FCD_RESET                    255 // Reset to bootloader
 
+// FCD Pro (V1.x) gain commands.. we get to manage gain distribution across the amps
+#define FCD_HID_CMD_SET_IF_GAIN1     117
+#define FCD_HID_CMD_SET_IF_GAIN2     120
+#define FCD_HID_CMD_SET_IF_GAIN3     121
+#define FCD_HID_CMD_SET_IF_GAIN4     123
+#define FCD_HID_CMD_SET_IF_GAIN5     124
+#define FCD_HID_CMD_SET_IF_GAIN6     125
+
+#define FCD_HID_CMD_GET_IF_GAIN1     157
+#define FCD_HID_CMD_GET_IF_GAIN2     160
+#define FCD_HID_CMD_GET_IF_GAIN3     161
+#define FCD_HID_CMD_GET_IF_GAIN4     163
+#define FCD_HID_CMD_GET_IF_GAIN5     164
+#define FCD_HID_CMD_GET_IF_GAIN6     165
+
 typedef enum
 {
 	TRFE_0_4,


### PR DESCRIPTION
Hi @pothosware folks, this PR adds:
 * support for building SoapyFCDPP on Debian stable (thus: Raspbian/Armbian) against standard packages (libsoapy0.6),
 * support for FCD Pro (V1.x) dongles,
 * detection of valid Alsa devices for multiple attached FCDs.

Please let me know if you would like this split up into smaller pieces!

This is currently operating as the SDR driver for OpenWebRX on my OrangePi Zero LTS.

Cheers, Phil (M6IPX), FUNcube dev team =)