### PR TITLE
Period option to manage latency on faster CPUs

### DIFF
--- a/Changelog.txt
+++ b/Changelog.txt
@@ -1,8 +1,9 @@
 Release 0.2.0 (pending)
 ==========================
 
-- support for building SoapyFCDPP on SoapySDR v0.6
+- support for building SoapyFCDPP on SoapySDR v0.6 (Debian 10)
 - support for FCD Pro (V1.x) dongles
+- period increased to 250msecs by default (adjustable) to reduce context switching rate on low power systems
 - detection of valid Alsa devices for multiple attached FCDs
 
 Release 0.1.1 (2019-01-26)

--- a/README.md
+++ b/README.md
@@ -6,70 +6,106 @@ https://github.com/pothosware/SoapyFCDPP/wiki
 
 ## What is this thing?
 
-This is my SoapySDR driver for the FUNcube dongle pro+. I have tested it on Raspberry Pi. I use it for streaming IQ data to GQRX.
+This is a SoapySDR driver for the FUNcube dongle pro+. It has been tested it on Raspberry Pi 3 & Orange Pi Zero LTS, typically used for streaming IQ data to GQRX.
 
 Unlike the gr-osmosdr it's doesn't depend on the gr-fcdproplus block but is standalone depending on libhidapi and ALSA. I believe this makes it a bit more approachable for hacking.
+
+If you intend to use this as a remote front-end, remember to build _on your target system_, not your local machine!
 
 ## Dependencies
 
 * SoapySDR
 * libasound2 (ALSA)
 * libhidapi
-* meson and ninja for building
+* cmake or meson and ninja for building
 
-### Ubuntu
+### Ubuntu / Debian
 
+(if you don't already have SoapySDR installed from source)
+```bash
+sudo apt-get install libsoapysdr-dev soapysdr-tools
+```
+(other dependencies)
 ```bash
 sudo apt-get install libhidapi-dev libasound2-dev
 ```
 
 ## Build with cmake
 
+Tested on Debian 10 with out-of-the-box SoapySDR and other dependencies.
+
 ```bash
 # build
-git clone https://github.com/ast/SoapyFCDPP.git
+git clone https://github.com/pothosware/SoapyFCDPP.git
 cd SoapyFCDPP
 mkdir build; cd build
 cmake ../
 make && sudo make install
+# Will put the driver in /usr/local/lib/SoapySDR/module0.6
 ```
 
 ## Build with meson
 
-I have only tested with the latest SoapySDR / SoapyRemote.
+Only tested with the latest SoapySDR / SoapyRemote from source.
 
 ```bash
 # build
-git clone https://github.com/ast/SoapyFCDPP.git
+git clone https://github.com/pothosware/SoapyFCDPP.git
 cd SoapyFCDPP/SoapyFCDPP
 meson build && cd build
 ninja install
 # Will put the driver in /usr/local/lib/SoapySDR/modules0.7
+```
 
-# Should then appear in the list:
+## Testing
+
+This driver should now appear in the driver list as `fcdpp`:
+
+```bash
 SoapySDRUtil --info
 ```
 
+### Local use
+
+You can access the driver directly from a SoapySDR client, a typical device string is:
+```bash
+driver=fcdpp,period=19200
 ```
-# Run server
+where `period` is optional but specifies the sample count per ALSA period (defaults to sample rate / 4 => 250msec latency).
+Adjust if you want lower latency at the cost of higher context switch rates (eg: an RPi3 can tolerate down to 2048 samples,
+however an OrangePi Zero LTS may kernel panic / become unstable below 9600, hence the default!)
+
+### Remote use
+
+You can also use SoapyRemote (or another SoapySDR remoting solution) to operate this driver as a headless front-end.
+
+On the remote system:
+```bash
 SoapySDRServer --bind="0.0.0.0:1234"
-
-# Device string in GQRX
-soapy=0,remote=hostname.local:1234,remote:driver=fcdpp
 ```
 
-* Input rate: 192000
+On the local system (eg: GQRX SoapySDR client):
 
-To access USB without being root you need this:
+ * Device string in GQRX: `soapy=0,remote=hostname.local:1234,remote:driver=fcdpp`
+ * Input rate: 192000 (if you have FCD Pro+, otherwise 96000)
+ * All other settings default (no decimation, zero bandwidth, LO frequency)
+
+## Permissions
+
+To access an FCD USB device for tuning/gain control etc. without being root you need this:
 
 ```
-# Udev rules for the Funcube Dongle Pro+ (0xfb31)
+# Udev rules for the Funcube Dongle Pro (0xfb56) & Pro+ (0xfb31)
 # Put this in:
 # /etc/udev/rules.d/81-funcube.rules
 
-# Udev rule for the Funcube Dongle to be used with libusb
-SUBSYSTEMS=="usb", ATTRS{idVendor}=="04d8", ATTRS{idProduct}=="fb31", GROUP="audio", MODE="0666", SYMLINK+="usbfcd"
+# Udev rule for the Funcube Dongle to be used with libusb (NB: SYMLINK is not necessary but convenient)
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="04d8", ATTRS{idProduct}=="fb56", GROUP="audio", MODE="0666", SYMLINK+="usbfcd1"
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="04d8", ATTRS{idProduct}=="fb31", GROUP="audio", MODE="0666", SYMLINK+="usbfcd2"
 ```
+
+NB: If you have GNU radio support for Funcube Dongles installed you may have what you need in `/lib/udev/rules.d/60-gr-fcdproplus.rules`
+or `/lib/udev/rules.d/60-libgnuradio-fcd*`.
 
 ## License
 

--- a/SoapyFCDPP/SoapyFCDPP.cpp
+++ b/SoapyFCDPP/SoapyFCDPP.cpp
@@ -11,6 +11,7 @@
 SoapyFCDPP::SoapyFCDPP(const std::string &hid_path, const std::string &alsa_device, const bool is_plus, const uint32_t override_period) :
     is_pro_plus(is_plus),
     d_pcm_handle(nullptr),
+    d_running_size(0),
     d_frequency(0),
     d_lna_gain(0),
     d_bias_tee(false),
@@ -27,8 +28,6 @@ SoapyFCDPP::SoapyFCDPP(const std::string &hid_path, const std::string &alsa_devi
     if (d_handle == nullptr) {
         throw std::runtime_error("hid_open_path failed to open: " + d_hid_path);
     }
-    // Sample buffer x 2 because complex data.
-    d_buff.resize(2 * d_period_size);
 }
 
 SoapyFCDPP::~SoapyFCDPP()
@@ -86,6 +85,9 @@ SoapySDR::ArgInfoList SoapyFCDPP::getStreamArgsInfo(const int direction, const s
 SoapySDR::Stream *SoapyFCDPP::setupStream(const int direction, const std::string &format, const std::vector<size_t> &channels, const SoapySDR::Kwargs &args)
 {
     SoapySDR_log(SOAPY_SDR_INFO, "setup stream");
+    if (d_pcm_handle!=nullptr) {
+        throw std::runtime_error("setupStream only one stream at a time");
+    }
     if (direction != SOAPY_SDR_RX) {
         throw std::runtime_error("setupStream only RX supported");
     }
@@ -109,6 +111,10 @@ SoapySDR::Stream *SoapyFCDPP::setupStream(const int direction, const std::string
     d_pcm_handle = alsa_pcm_handle(d_alsa_device.c_str(), (unsigned int)d_sample_rate, d_period_size, SND_PCM_STREAM_CAPTURE);
     assert(d_pcm_handle != nullptr);
     
+    // Save ALSA period size & adjust sample buffer (x 2 because complex data).
+    d_running_size = d_period_size;
+    d_buff.resize(2 * d_running_size);
+
     return (SoapySDR::Stream *) this;
 }
 
@@ -216,7 +222,9 @@ int SoapyFCDPP::readStream(SoapySDR::Stream *stream,
             // read but no more than one ALSA period. Less will probably be requested.
             n_err = snd_pcm_readi(d_pcm_handle,
                                   &d_buff[0],
-                                  std::min<size_t>(d_period_size, numElems));
+                                  std::min<size_t>(d_running_size, numElems));
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wimplicit-fallthrough"
             if(n_err >= 0) {
                 // read ok, convert and return.
 #if SOAPY_SDR_API_VERSION >= 0x00070000
@@ -229,6 +237,7 @@ int SoapyFCDPP::readStream(SoapySDR::Stream *stream,
 #endif
                 return (int) n_err;
             } // error, fallthrough
+#pragma GCC diagnostic pop
         case SND_PCM_STATE_XRUN:
             err = (int) n_err;
             // try to recover from error.
@@ -555,18 +564,39 @@ SoapySDR::ArgInfoList SoapyFCDPP::getSettingInfo(void) const
     SoapySDR::ArgInfoList settings;
     
     SoapySDR_log(SOAPY_SDR_DEBUG, "getSettingInfo");
-    
+
+    SoapySDR::ArgInfo setting;
+    setting.key = "period";
+    setting.value = "0";
+    setting.type = SoapySDR::ArgInfo::Type::INT;
+    // Empirical testing shows ALSA supports periods in this range...
+    setting.range = SoapySDR::Range(d_sample_rate/1000, d_sample_rate/2, d_sample_rate/100);
+    settings.push_back(setting);
+
     return settings;
 }
 
 void SoapyFCDPP::writeSetting(const std::string &key, const std::string &value)
 {
     SoapySDR_log(SOAPY_SDR_DEBUG, "writeSetting");
+    if (d_pcm_handle!=nullptr)
+        SoapySDR_log(SOAPY_SDR_WARNING, "writeSetting, will not affect currently open stream");
+    if ("period"==key) {
+        uint32_t period;
+        sscanf(value.c_str(), "%u", &period);
+        if (period<d_sample_rate/1000 || period>d_sample_rate/2) {
+            SoapySDR_logf(SOAPY_SDR_ERROR, "writeSetting: unsupported period value (%u)", period);
+            return;
+        }
+        d_period_size = period;
+    }
 }
 
 std::string SoapyFCDPP::readSetting(const std::string &key) const
 {
     SoapySDR_log(SOAPY_SDR_DEBUG, "readSetting");
+    if ("period"==key)
+        return std::to_string(d_period_size);
     return "empty";
 }
 

--- a/SoapyFCDPP/SoapyFCDPP.hpp
+++ b/SoapyFCDPP/SoapyFCDPP.hpp
@@ -60,7 +60,7 @@ private:
     hid_device *d_handle;
     
 public:
-    SoapyFCDPP(const std::string &hid_path, const std::string &alsa_device, const bool is_plus);
+    SoapyFCDPP(const std::string &hid_path, const std::string &alsa_device, const bool is_plus, const uint32_t overide_period);
     ~SoapyFCDPP();
     
     // Identification API

--- a/SoapyFCDPP/SoapyFCDPP.hpp
+++ b/SoapyFCDPP/SoapyFCDPP.hpp
@@ -33,6 +33,7 @@ private:
     const bool is_pro_plus;
     snd_pcm_t* d_pcm_handle;
     uint32_t d_period_size;
+    uint32_t d_running_size;
     std::vector<int32_t> d_buff;
 
     // Device properties


### PR DESCRIPTION
This change introduces an optional `period` argument for the SoapyFCDPP driver that allows adjustment of the ALSA sample period (block size), from the default of `sampleRate/4` (resulting in 250msecs latency).

[edited to note] This remains compatible with #11 (which dynamically uses `d_period_size`), altering the typical mapped buffer size to match the specified period.