### PR TITLE
Bug fixes: direct buffer API

### DIFF
--- a/SoapyFCDPP/SoapyFCDPP.cpp
+++ b/SoapyFCDPP/SoapyFCDPP.cpp
@@ -330,7 +330,7 @@ retry:
                 SoapySDR_logf(SOAPY_SDR_ERROR, "snd_pcm_mmap_begin error: %s", snd_strerror(err));
                 goto retry;
             }
-            buffs[0] = ((char *)area->addr) + d_mmap_offset;
+            buffs[0] = ((char *)area->addr) + d_mmap_offset * 4;
             // ensure API contract for handle (unused by us)
             handle = 0;
             // record mmap is valid

--- a/SoapyFCDPP/SoapyFCDPP.cpp
+++ b/SoapyFCDPP/SoapyFCDPP.cpp
@@ -306,6 +306,13 @@ retry:
     // check we are in a valid state (prepared, running or xrun)
     snd_pcm_state_t state = snd_pcm_state(d_pcm_handle);
     switch (state) {
+        case SND_PCM_STATE_SETUP:
+            SoapySDR_log(SOAPY_SDR_TRACE, "..acquireReadBuffer:preparing");
+            if((err = snd_pcm_prepare(d_pcm_handle)) < 0) {
+                // could not prepare
+                SoapySDR_logf(SOAPY_SDR_ERROR, "snd_pcm_prepare %s", snd_strerror(err));
+                break;
+            } // fallthrough
         case SND_PCM_STATE_PREPARED:
             SoapySDR_log(SOAPY_SDR_TRACE, "..acquireReadBuffer:starting");
             err = snd_pcm_start(d_pcm_handle);


### PR DESCRIPTION
After testing with my [own remoting solution](/phlash/SoapyTCPRemote), updated to use the direct buffer API, I discovered a couple of bugs:

 * incorrect calculation of direct buffer pointer (correct calculation was already in `readStream`)
 * missing call to `snd_pcm_prepare` if a stream is deactivated and then re-activated (also in `readStream`)

turns out I should read nearby code :smile: 