### PR TITLE
bug fix: read initial tuning frequency at startup

### DIFF
--- a/SoapyFCDPP/SoapyFCDPP.cpp
+++ b/SoapyFCDPP/SoapyFCDPP.cpp
@@ -30,6 +30,7 @@ SoapyFCDPP::SoapyFCDPP(const std::string &hid_path, const std::string &alsa_devi
     if (d_handle == nullptr) {
         throw std::runtime_error("hid_open_path failed to open: " + d_hid_path);
     }
+    d_frequency = (double)fcdpp_get_freq_hz(d_handle);
 }
 
 SoapyFCDPP::~SoapyFCDPP()


### PR DESCRIPTION
Discovered while using this module in a test program, the tuning frequency always came back as zero until it was set, despite the FCD itself being tuned elsewhere.